### PR TITLE
Remove AM/PM from times in announcements

### DIFF
--- a/_telegram/announcements.py
+++ b/_telegram/announcements.py
@@ -41,5 +41,5 @@ for dt, arr in parsed_announcements.items():
         continue
     print('Announce: ', ann_time)
     for txt in arr:
-        bot.send_message(chat_id=CHAT_ID, text=('Coming up at #wmhack #wmhack2023 \n🕰️'+(ann_time.strftime('%H:%M%p'))+' \n\n'+txt))
+        bot.send_message(chat_id=CHAT_ID, text=('Coming up at #wmhack #wmhack2023 \n🕰️'+(ann_time.strftime('%H:%M'))+' \n\n'+txt))
         time.sleep(1)


### PR DESCRIPTION
The announcement already uses a 24h clock, so the suffix indicating the day part is superfluous.