### PR TITLE
Use actions/checkout@v3

### DIFF
--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo content
-        uses: actions/checkout@v2 # checkout the repository content
+        uses: actions/checkout@v3 # checkout the repository content
 
       - name: setup python
         uses: actions/setup-python@v4


### PR DESCRIPTION
This is the latest version of actions/checkout@v3 using node.js 16 that no longer throws warnings "Node.js 12 actions are deprecated."