### PR TITLE
Specify python version 3.10 for action

### DIFF
--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: setup python
         uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
 
       - name: install python packages
         run: |


### PR DESCRIPTION
This prevents a warning when running the action: "The `python-version` input is not set. The version of Python currently in `PATH` will be used."